### PR TITLE
auto-calculate number of vehicles and number of Hino vehicles

### DIFF
--- a/models/partner/custom_partner.py
+++ b/models/partner/custom_partner.py
@@ -2,38 +2,54 @@ import re
 from odoo import models, fields, api
 from odoo.exceptions import ValidationError
 
+
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    x_potential_count = fields.Integer(string="Lead") # x_potential_count = fields.Integer(compute="_compute_potential_count", string="Potential") - Logic
-    x_contract_count = fields.Integer(string="Contract") # x_contract_count = fields.Integer(compute="_compute_contract_count", string="Contracts") - Logic
-    x_vehicle_management_count = fields.Integer(string="Vehicle Management") # x_vehicle_management_count = fields.Integer(compute="_compute_vehicle_management_count", string="Vehicle Management") - Logic
+    # x_potential_count = fields.Integer(compute="_compute_potential_count", string="Potential") - Logic
+    x_potential_count = fields.Integer(string="Lead")
+    # x_contract_count = fields.Integer(compute="_compute_contract_count", string="Contracts") - Logic
+    x_contract_count = fields.Integer(string="Contract")
+    # x_vehicle_management_count = fields.Integer(compute="_compute_vehicle_management_count", string="Vehicle Management") - Logic
+    x_vehicle_management_count = fields.Integer(string="Vehicle Management")
     company_type = fields.Selection(
-            selection_add=[('internal_hmv', 'Internal HMV')],
-        )
-    x_dealer_id = fields.Char(string='Dealer', readonly=True) # liên quan đến dealer.group - chưa có giải thích cụ thể
-    x_dealer_branch_id = fields.Many2one('res.company', string='Dealer Branch', default=lambda self: self.env.company, tracking=True, readonly=True)
+        selection_add=[('internal_hmv', 'Internal HMV')],
+    )
+    # liên quan đến dealer.group - chưa có giải thích cụ thể
+    x_dealer_id = fields.Char(string='Dealer', readonly=True)
+    x_dealer_branch_id = fields.Many2one(
+        'res.company', string='Dealer Branch', default=lambda self: self.env.company, tracking=True, readonly=True)
     x_customer_type = fields.Selection(
-        [('last_customer', 'Last Customer'), ('third_party', 'Third Party'), ('body_maker', 'Body Maker')],
+        [('last_customer', 'Last Customer'), ('third_party',
+                                              'Third Party'), ('body_maker', 'Body Maker')],
         string='Customer Type', default='last_customer', tracking=True
     )
     x_name = fields.Char(string='Name', tracking=True)
     x_contact_address = fields.Char(string="Address", store=True)
     x_function = fields.Char(string='Function')
-    x_customer_code = fields.Char(string='Customer Code', tracking=True, readonly=True, copy=False)
+    x_customer_code = fields.Char(
+        string='Customer Code', tracking=True, readonly=True, copy=False)
     x_district = fields.Char(string='District')
     x_state_id = fields.Many2one('res.country.state', string="State/Province")
-    x_field_sale_id = fields.Many2one('sale.area',string='Field Sale')
-    x_currently_rank_id = fields.Many2one('customer.rank', string='Currently Rank')
-    x_business_registration_id = fields.Char(string='Business Registration ID', help='Business Registration ID')
-    x_identity_number = fields.Char(string='Identity Number', help='National or Personal Identity Number')
-    x_industry_id = fields.Many2one('res.partner.industry', string='Industry', tracking=True)
+    x_field_sale_id = fields.Many2one('sale.area', string='Field Sale')
+    x_currently_rank_id = fields.Many2one(
+        'customer.rank', string='Currently Rank')
+    x_business_registration_id = fields.Char(
+        string='Business Registration ID', help='Business Registration ID')
+    x_identity_number = fields.Char(
+        string='Identity Number', help='National or Personal Identity Number')
+    x_industry_id = fields.Many2one(
+        'res.partner.industry', string='Industry', tracking=True)
     x_activity_area = fields.Char(string='Activity Area', tracking=True)
-    x_service_contract = fields.Boolean(string='Service Contact', tracking=True)
+    x_service_contract = fields.Boolean(
+        string='Service Contact', tracking=True)
 
-    x_number_of_vehicles = fields.Integer(string='Number of Vehicles')
-    x_hino_vehicle = fields.Integer(string='Hino Vehicle')
-    x_allow_dealer_id = fields.Many2many('res.company', string="Dealers allowed to sale with this customer", readonly=1)
+    x_number_of_vehicles = fields.Integer(
+        string='Number of Vehicles', compute="_compute_number_of_vehicles")
+    x_hino_vehicle = fields.Integer(
+        string='Hino Vehicle', compute="_compute_number_of_vehicles")
+    x_allow_dealer_id = fields.Many2many(
+        'res.company', string="Dealers allowed to sale with this customer", readonly=1)
     x_number_repair_order = fields.Integer(string='Number of Repair Order')
     x_cumulative_points = fields.Integer(string='Cumulative Points')
     x_register_sale_3rd_id = fields.Many2one(
@@ -57,7 +73,8 @@ class ResPartner(models.Model):
                     []
                 )[0]['x_quantity']
                 record.x_hino_vehicle = self.env['owned.team.car.line'].read_group(
-                    [('lead_id', '=', record.x_lead_id), ('x_is_hino_vehicle', '=', True)],
+                    [('lead_id', '=', record.x_lead_id),
+                     ('x_is_hino_vehicle', '=', True)],
                     ['x_quantity:sum'],
                     []
                 )[0]['x_quantity']
@@ -73,6 +90,7 @@ class ResPartner(models.Model):
                     [('lead_id', '=', partner.x_lead_id)])
             else:
                 partner.x_owned_car_line_ids = self.env['owned.team.car.line']
+
     @api.constrains('phone')
     def _check_phone_unique(self):
         for record in self:
@@ -109,7 +127,6 @@ class ResPartner(models.Model):
         if self.company_type == 'internal_hmv':
             return
         self.is_company = (self.company_type == 'company')
-    
 
     @api.constrains('x_business_registration_id')
     def _check_business_registration_id(self):


### PR DESCRIPTION
```
fix: auto-calculate number of vehicles and number of Hino vehicles

- Updated the `number_of_vehicle` and `number_of_hino_vehicle` fields to automatically calculate the sum of vehicles.
- Ensured that the sum reflects accurate and up-to-date information.
- Improved the efficiency and reliability of the vehicle data management.

This change addresses the issue where the vehicle counts needed to be manually updated, reducing potential errors and saving time.
```